### PR TITLE
Remove default config

### DIFF
--- a/src/overseer/api.clj
+++ b/src/overseer/api.clj
@@ -38,3 +38,7 @@
   ([] (abort ""))
   ([msg]
     (throw (ex-info msg {:overseer/status :aborted}))))
+
+(def default-config
+  {:datomic {:uri "datomic:free://localhost:4334/overseer"}
+   :sleep-time 10000})


### PR DESCRIPTION
This removes default config from being added by the system, and instead
moves it to the api namespace to give the option to the user.
