### PR TITLE
Refactor valid graph assert handling

### DIFF
--- a/src/overseer/core.clj
+++ b/src/overseer/core.clj
@@ -3,14 +3,14 @@
   (:require [datomic.api :as d]
             [clojure.set :as set]))
 
-(defn assert-valid-graph
-  "Assert that all dependencies specified are present in a graph"
+(defn missing-dependencies
+  "Compute dependencies that have been referenced but not
+   specified in a graph, if any"
   [graph]
-  (dorun
-    (for [[k deps] graph
-          d deps]
-      (assert (get graph d) (str "Couldn't resolve dependency: " d))))
-  true)
+  (->> (for [[k deps] graph
+             d deps]
+         (when-not (get graph d) d))
+       (filter identity)))
 
 (defn job-assertion
   "Construct a single job assertion, given a type and optional

--- a/test/overseer/core_test.clj
+++ b/test/overseer/core_test.clj
@@ -8,12 +8,12 @@
 
 (use-fixtures :each test-utils/setup-db-fixtures)
 
-(deftest test-assert-valid-graph
+(deftest test-missing-dependencies
   (let [g1 {:foo []
             :bar [:foo]}
         g2 {:baz [:quux]}] ; Invalid, quux not specified
-    (is (= true (core/assert-valid-graph g1)))
-    (is (thrown? AssertionError (core/assert-valid-graph g2)))))
+    (is (= [] (core/missing-dependencies g1)))
+    (is (= [:quux] (core/missing-dependencies g2)))))
 
 (deftest test-jobs-ready
   (let [conn (test-utils/connect)


### PR DESCRIPTION
Instead of asserting / side effecting multiple times, compute a list of
missing dependencies (if any) and assert emptiness once
