### PR TITLE
(Discussion) Suppress ineligible job exceptions

### DIFF
--- a/src/overseer/schema.clj
+++ b/src/overseer/schema.clj
@@ -59,7 +59,8 @@
                     status (ffirst result)]
                 (if-not (#{:finished :aborted :failed} status)
                   [[:db/add [:job/id job-id] :job/status :started]]
-                  (throw (Exception. (str "Job status " status " not eligible for start.")))))})})
+                  (throw (ex-info (str "Job status " status " not eligible for start.")
+                                  {:overseer/error :ineligible}))))})})
 
 (defn install
   "Install Overseer's schema and DB functions into Datomic"


### PR DESCRIPTION
When a worker attempts to reserve a job that's ineligible for start
the reservation DB function throws an exception. This gets caught by the
default exception handler, and propagated up to Sentry. This causes tons
of noise in Sentry, and there's really nothing that can be done on the
user's behalf in response.

This modifies the reserve-job db function to throw a specially-marked
exception (with `ex-info`), and the default exception handler is
modified to notice exceptions of this type and not propagate them
through to Sentry.

This PR uses work from https://github.com/framed-data/overseer/pull/34,
and is intended largely for discussion about whether or not it's the
right strategy to take here.
