### PR TITLE
Job reservation: Use standalone exception handler

### DIFF
--- a/src/overseer/schema.clj
+++ b/src/overseer/schema.clj
@@ -59,7 +59,8 @@
                     status (ffirst result)]
                 (if-not (#{:finished :aborted :failed} status)
                   [[:db/add [:job/id job-id] :job/status :started]]
-                  (throw (Exception. (str "Job status " status " not eligible for start.")))))})})
+                  (throw (ex-info (format "Job %s: status %s not eligible for start." job-id status)
+                                  {:overseer/error :ineligible}))))})})
 
 (defn install
   "Install Overseer's schema and DB functions into Datomic"

--- a/src/overseer/worker.clj
+++ b/src/overseer/worker.clj
@@ -14,7 +14,7 @@
        (filter (comp job-handlers :job/type))))
 
 (defn reserve-job
-  "Attempt to reserve a job and return it, or return nil on failure"
+  "Attempt to reserve a job and return it"
   [exception-handler conn job]
   {:pre [job]}
   (let [{:keys [job/id job/type]} job]
@@ -29,9 +29,8 @@
    nil on failure"
   [conn config jobs]
   {:pre [(not (empty? jobs))]}
-  (let [job (rand-nth jobs)
-        ex-handler (errors/->default-exception-handler config job)]
-    (when (reserve-job ex-handler conn job)
+  (let [job (rand-nth jobs)]
+    (when (reserve-job errors/reserve-exception-handler conn job)
       job)))
 
 (defn invoke-handler


### PR DESCRIPTION
Previously the job reservation function used the standard exception
handler, which logs errors to timbre and sends them to Sentry. This led
to lots of ineligible status exceptions in Sentry, which is a
non-actionable item that should be suppressed. The approach here is
changed to use a separate exception handler for job reservation, which
catches/logs ineligible starts and logs them before bailing out (no
Sentry).

By doing this, only 1 remaining caller of the default handler remained,
so we can just inline it with the standard job exception handler.
