### PR TITLE
Executor: Inline core/reserve

### DIFF
--- a/src/overseer/core.clj
+++ b/src/overseer/core.clj
@@ -50,13 +50,6 @@
   {:pre [job-id]}
   (d/pull db '[:*] [:job/id job-id]))
 
-(defn reserve
-  "Transact the DB to reserve the given job, or throw an exception.
-   Requires the overseer.schema/reserve-job database function to be in-schema."
-  [conn job-id]
-  {:pre [job-id]}
-  @(d/transact conn [[:reserve-job job-id]]))
-
 (defn ent-dependents
   "Find all jobs entities that depend on ent"
   [db ent]

--- a/src/overseer/executor.clj
+++ b/src/overseer/executor.clj
@@ -19,7 +19,7 @@
     (errors/try-thunk exception-handler
       (fn []
         (timbre/info (format "Reserving job %s (%s)" id type))
-        (core/reserve conn id)
+        @(d/transact conn [[:reserve-job id]])
         (timbre/info "Reserved job" id)
         job))))
 


### PR DESCRIPTION
There's really no reason for this to exist as a standalone function;
it's better encapsulated in `executor/reserve`
