### PR TITLE
Cleanup overseer.{status,worker}

### DIFF
--- a/src/overseer/status.clj
+++ b/src/overseer/status.clj
@@ -6,24 +6,22 @@
 (defn jobs-with-status
   "Find all job IDs with a given status (e.g. :unstarted)"
   [db status]
-  (->> (d/q '[:find ?jid
+  (->> (d/q '[:find [?jid ...]
               :in $ ?status
               :where [?e :job/status ?status]
                      [?e :job/id ?jid]]
             db
             status)
-       (map first)
-       (set)))
+       set))
 
 (defn jobs-unstarted
   "Find all job IDs that are not yet started."
   [db]
-  (->> (d/q '[:find ?jid
+  (->> (d/q '[:find [?jid ...]
               :where [?e :job/status :unstarted]
                      [?e :job/id ?jid]]
             db)
-       (map first)
-       (into #{})))
+       set))
 
 (defn jobs-ready
   "Find all job IDs that are ready to run.
@@ -33,7 +31,7 @@
   (let [unstarted (jobs-unstarted db)]
     (set/difference
       unstarted
-      (->> (d/q '[:find ?jid
+      (->> (d/q '[:find [?jid ...]
                   :in $ [?unstarted-jids ...]
                   :where [?j :job/id ?unstarted-jids]
                          [?j :job/id ?jid]
@@ -42,5 +40,4 @@
                          [(not= :finished ?djs)]]
                 db
                 unstarted)
-           (map first)
-           (into #{})))))
+           set))))

--- a/src/overseer/worker.clj
+++ b/src/overseer/worker.clj
@@ -1,4 +1,4 @@
-(ns ^:no-doc overseer.worker
+(ns overseer.worker
   "A Worker is the main top-level unit of Overseer. Internally, it acts as a
    supervisor for several processes that coordinate to select ready
    jobs from the queue and execute them"
@@ -12,11 +12,11 @@
               [heartbeat :as heartbeat]
               [status :as status])))
 
-(def detector-sleep-time
+(def ^:private detector-sleep-time
   "Pause time between ready job detector runs (ms)"
   2000)
 
-(defn ready-job-entities
+(defn- ready-job-entities
   "Return the set of job entities that are ready to execute,
    filtering to those defined in job-handlers (this allows different
    nodes to solely execute certain types of jobs, if desired)"


### PR DESCRIPTION
- Use Datomic collection binds `[?e ...]` and avoid `map first` clutter
- Use `set` consistently
- Docs: `overseer.worker` is public!
