### PR TITLE
Serialize job arguments as EDN

### DIFF
--- a/src/overseer/api.clj
+++ b/src/overseer/api.clj
@@ -13,21 +13,22 @@
   "Map of default configuration (connects to local Datomic)"
   config/default-config)
 
-(def start
-  "Start the system as a library
-   (start config handler-map)"
+(def
+  ^{:doc "Start the system as a library, given a map of
+  {job-type job-handler}"
+    :arglists '([config job-handlers])}
+  start
   worker/start!)
 
-(def job-assertion
-  "Construct a single job assertion, given a type and optional
-   user-provided txn data
-   (job-assertion job-type)
-   (job-assertion job-type arg-map)
-
-   Ex:
-     (def tx1 (job-assertion :my-job-type-1))
-     (def tx2 (job-assertion :my-job-type-2 {:job/organization-id 123}))
-     @(d/transact conn [tx1 tx2])"
+(def
+  ^{:doc "Construct a single unstarted job assertion, given a type and optional
+  arguments (serializable via EDN)
+  Ex:
+    (let [tx1 (job-assertion :my-job-type-1)
+          tx2 (job-assertion :my-job-type-2 {:organization-id 123})]
+      @(d/transact conn [tx1 tx2]))"
+    :arglists '([job-type] [job-type args])}
+  job-assertion
   core/job-assertion)
 
 (defn ->graph-txn

--- a/src/overseer/schema.clj
+++ b/src/overseer/schema.clj
@@ -19,6 +19,13 @@
      :db.install/_attribute :db.part/db}
 
     {:db/id (d/tempid :db.part/db)
+     :db/ident :job/args
+     :db/valueType :db.type/string
+     :db/cardinality :db.cardinality/one
+     :db/doc "The arguments passed to a job (serialized as EDN)"
+     :db.install/_attribute :db.part/db}
+
+    {:db/id (d/tempid :db.part/db)
      :db/ident :job/status
      :db/valueType :db.type/keyword
      :db/cardinality :db.cardinality/one


### PR DESCRIPTION
This is a revision of https://github.com/framed-data/overseer/pull/42 ;
to recap:

"Previously, any user-specified arguments to jobs needed to already
exist as attributes in Datomic. This is undesirable for several reasons,
namely that it is inflexible, and frustratingly slow to iterate/change
as all possible attributes have to be enumerated and transacted into the
DB. Furthermore it unnecessarily couples that aspect of the system to
Datomic, although backend indifference is not a design goal yet."

In short, `:job/args` stores arbitrary as EDN and is transparently
se-/de- serialized. However, the design is slightly different compared
to #42, namely, the signature of process/post-process is _not_ changed.
Instead, `(:job/args job)` is the standard interface to access the
parsed EDN. Given this design, it will be trivial to modify any existing
accessors (i.e. `->stream`) to check for the args attribute, or else
default to the old style as the change is being rolled out.
