### PR TITLE
Don't pass output of `pre-process` into `process`

### DIFF
--- a/src/overseer/executor.clj
+++ b/src/overseer/executor.clj
@@ -28,7 +28,7 @@
    expecting a job argument, or a map of the following structure:
 
      ; Optional, runs prior to main processing function and can be
-     ; used to set up prerequisite state, for example.
+     ; used to ex: set up prerequisite state
      :pre-process (fn [job] ...)
 
      ; Required, the main processing function.
@@ -44,8 +44,8 @@
              :or {pre-process (fn [job] job)
                   post-process (fn [job res] res)}} handler]
         (assert process "Expected handler map to define :process function")
-        (->> (pre-process job)
-             (process)
+        (pre-process job)
+        (->> (process job)
              (post-process job)))
     (fn? handler)
       (handler job)

--- a/test/overseer/api_test.clj
+++ b/test/overseer/api_test.clj
@@ -67,16 +67,11 @@
 
     (testing "harnessing missing keys"
       (let [handler {:process (fn [job] (:foo job))}
-            pre-wrapper (fn [f]
-                          (fn [job]
-                            (f (assoc job :foo :bar))))
             post-wrapper (fn [f]
                            (fn [job res]
                              (swap! state inc)))
-            pre-harnessed (api/harness handler :pre-process pre-wrapper)
             post-harnessed (api/harness handler :post-process post-wrapper)]
         (reset! state 0)
-        (is (= :bar (exc/invoke-handler pre-harnessed job)))
         (is (= 0 @state))
         (exc/invoke-handler post-harnessed job)
         (is (= 1 @state))))))

--- a/test/overseer/executor_test.clj
+++ b/test/overseer/executor_test.clj
@@ -46,10 +46,9 @@
     (let [job {:job/type :foo}
           handler-fn (fn [job] (reduce + 0 [1 2 3 4 5]))
           handler-map {:pre-process (fn [job]
-                                      (assert (= (:job/type job) :foo))
-                                      (assoc job :bar :quux))
+                                      (assert (= (:job/type job) :foo)))
                        :process (fn [job]
-                                  (assert (= (:bar job) :quux))
+                                  (assert (= (:job/type job) :foo))
                                   [1 2 3 4 5])
                        :post-process (fn [job res] (reduce + 0 res))}
           bad-handler "not-fn-or-map"]


### PR DESCRIPTION
The thinking here was the pre-process could be a place to modify context
and do dependency injection of sorts if desired; however it leads to
unnecessary API confusion ("even if you're just using it to set up
prerequisite state, make sure your pre-process function returns a job,
otherwise things will break mysteriously"), and harnesses are the
preferred mechanism to transform any job stage, not just pre-processors.

This is a breaking change for code that uses pre-processors to transform
jobs; however changing those harnesses to modify the process stage
instead should be trivial.
