### PR TITLE
AOT-compile Overseer.runner

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,4 +17,5 @@
                  [clj-http "1.1.2"]
                  [raven-clj "1.1.0"]
                  [io.framed/std "0.1.2"]]
+  :aot [overseer.runner]
   :plugins [[codox "0.8.13"]])


### PR DESCRIPTION
overseer.runner is used by the launcher script included with Overseer.
It used to be AOT-compiled, but this was disabled as AOT compilation
causes issues with applications that need to modify dependency versions

See https://github.com/onyx-platform/onyx/issues/339. This re-enables
AOT-compilation for that namespace, but uses the same fix strategy of
requiring namespaces at runtime and resolving symbols which should
address the issue. This probably comes at some minor perf cost, but is
only run once at runtime.
