### PR TITLE
Re-mark overseer.worker as `^:no-doc`

### DIFF
--- a/src/overseer/worker.clj
+++ b/src/overseer/worker.clj
@@ -1,4 +1,4 @@
-(ns overseer.worker
+(ns ^:no-doc overseer.worker
   "A Worker is the main top-level unit of Overseer. Internally, it acts as a
    supervisor for several processes that coordinate to select ready
    jobs from the queue and execute them"


### PR DESCRIPTION
I spaced out and removed the mark since the system is started with
`worker/start!` but this is publicly aliased as `api/start`
