### PR TITLE
Use gitbook@2.4.3

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,7 +1,7 @@
 {
   "title": "Overseer",
   "language": "en",
-  "gitbook": ">=2.0.0",
+  "gitbook": "2.4.3",
   "structure": {
     "readme": "README.md",
     "summary": "doc/guide/SUMMARY.md"


### PR DESCRIPTION
Hey @andrewberls, following up on our Slack conversation.

`gitbook@2.5.0` and above (latest current version is `2.6.4`) don't accept `structure.summary` to be a file that's not in the `root` folder. (Because it opens a can of worms and can have lots of unexpected/strange side effects that would be even more confusing for users).

We'll improve the error message so it reflects that, and more importantly the `2.7.0` release will add a `root` option to `book.json` that you will probably want to use and have set as `"root": "doc/guide/"` (as soon as the `2.7.0` release is out).

In the meantime locking your `gitbook` `version` to `2.4.3` works, so that's exactly what this PR does :)