### PR TITLE
Experimental: Add JDBC Store implementation

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -2,8 +2,10 @@
 # out of the box. All options are shown here for completeness.
 
 # Required
-datomic:
-  uri: datomic:free://localhost:4334/overseer
+store:
+  adapter: datomic
+  config:
+    uri: datomic:free://localhost:4334/overseer
 
 # Optional: How to sleep (in ms) between ready job detector runs
 # (ready jobs are periodically cached)

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,9 @@
                  [io.framed/std "0.2.5"]
                  [aysylu/loom "1.0.0"]
                  [org.clojure/java.jdbc "0.7.0-alpha3"]
+                 [honeysql "0.8.2"]
                  [com.h2database/h2 "1.4.195"]
-                 [com.velisco/herbert "0.7.0"]]
+                 [com.velisco/herbert "0.7.0"]
+                 [clj-time "0.12.2"]]
   :plugins [[codox "0.8.13"]]
   :codox {:output-dir "doc/api"})

--- a/src/overseer/executor.clj
+++ b/src/overseer/executor.clj
@@ -73,7 +73,7 @@
             (swap! ready-jobs disj job)
 
             (timbre/info (format "Reserving job %s (%s)" job-id (:job/type job)))
-            (if-let [reserved-job (core/reserve-job store job)]
+            (if-let [reserved-job (core/reserve-job store job-id)]
               (do (timbre/info "Reserved job" job-id)
                   (reset! current-job job)
                   (run-job config store job-handlers job)

--- a/src/overseer/store/jdbc.clj
+++ b/src/overseer/store/jdbc.clj
@@ -1,0 +1,241 @@
+(ns ^:no-doc overseer.store.jdbc
+  "Implementation of overseer.core/Store for JDBC"
+  (:require [clojure.java.jdbc :as j]
+            [clojure.set :as set]
+            [clojure.string :as string]
+            (clj-time
+              [core :as clj-time]
+              [jdbc]) ; Requiring extends necessary coercion protocols
+            [framed.std.core :as std]
+            [honeysql.core :as sql]
+            (loom graph)
+            (overseer
+              [core :as core]
+              [util :as util])))
+
+(def status-code
+  {:unstarted 0
+   :started 1
+   :finished 2
+   :failed 3
+   :aborted 4})
+
+(def status
+  (set/map-invert status-code))
+
+(defn job->jdbc-map [job]
+  {:pre [job]}
+  (let [{:keys [job/id job/type job/args job/status
+                job/failure job/heartbeat]} job]
+    (-> {:id id
+         :type (name type)
+         :status (get status-code status)}
+        (std/when-assoc :args (some-> args std/to-edn))
+        (std/when-assoc :failure (some-> failure std/to-edn))
+        (std/when-assoc :heartbeat heartbeat))))
+
+(defn jdbc-map->job [jdbc-map]
+  {:pre [jdbc-map]}
+  (-> (std/map-kv #(keyword "job" (name %)) identity jdbc-map)
+      (update :job/status (partial get status))
+      (update :job/type keyword)
+      (util/when-update :job/args std/from-edn)
+      (util/when-update :job/failure std/from-edn)))
+
+(defn query-job
+  "Return a Job map for the given job-id; throws if not found"
+  [db-spec job-id]
+  (->> {:select [:*] :from [:overseer_jobs] :where [:= :id job-id]}
+       sql/format
+       (j/query db-spec)
+       first
+       (std/flip select-keys [:id :type :status :args :failure :heartbeat])
+       jdbc-map->job))
+
+(defn query-lock-version [db-spec job-id]
+  (->> {:select [:lock_version] :from [:overseer_jobs] :where [:= :id job-id]}
+       sql/format
+       (j/query db-spec)
+       first
+       :lock_version))
+
+(defn update-job
+  "Attempt to update attributes of a single job using optimistic locking;
+  Returns job-id if record updated, else nil if job is stale
+
+  where-map - map of {keyword-column-name value} to scope update. id/lock_version
+              are automatically added to the final where clause
+  set-map - map of {keyword-column-name value} of new attributes to set"
+  [db-spec job-id where-map set-map]
+  (let [lock-version (query-lock-version db-spec job-id)
+
+        where-map'
+        (merge {:id job-id :lock_version lock-version} where-map)
+
+        set-map'
+        (merge {:lock_version (inc lock-version) :updated_at (clj-time/now)} set-map)
+
+        num-rows-updated
+        (->> {:update :overseer_jobs
+              :set set-map'
+              :where (into [:and] (for [[k v] where-map'] [:= k v]))}
+             sql/format
+             (j/db-do-prepared db-spec)
+             first)]
+    ; If no rows updated - stale object, return nil
+    (when (= 1 num-rows-updated)
+      job-id)))
+
+(defn- direct-dependents
+  "Find the set of all Job IDs that directly depend on any of given `job-ids`"
+  [db-spec job-ids]
+  (->> {:select [:job_id]
+        :modifiers [:distinct]
+        :from [:overseer_dependencies]
+        :where [:in :dep_id (seq job-ids)]}
+       sql/format
+       (j/query db-spec)
+       (map :job_id)
+       set))
+
+(defn dependents [db-spec job-id]
+  "Returns the set of all Job IDs that depend upon given `job-id`, both
+  directly and transitively"
+  (loop [all-dependents #{}
+         visited #{}
+         to-visit #{job-id}]
+    (if (empty? to-visit)
+      (set all-dependents)
+      (let [dependents (direct-dependents db-spec to-visit)
+            all-dependents' (set/union all-dependents dependents)
+            visited' (set/union visited to-visit)
+            to-visit' (set/difference dependents visited')]
+        (recur all-dependents' visited' to-visit')))))
+
+(defn job-dep-jdbc-maps
+  "Return a seq of dependency rows to insert for a Graph<Job>"
+  [graph]
+  (let [edge->dep
+        (fn [[src dest]]
+          {:job_id (:job/id src)
+           :dep_id (:job/id dest)})]
+    (->> graph
+         loom.graph/edges
+         (map edge->dep))))
+
+(def default-table-opts
+  "Backend-specific system configuration options"
+  {:mysql
+   {:table-spec "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC"}})
+
+(defn install' [adapter db-spec]
+  (j/db-do-commands
+    db-spec
+    [(j/create-table-ddl
+       :overseer_jobs
+       [[:id "VARCHAR(64) PRIMARY KEY"]
+        [:type "VARCHAR(255)"]
+        [:args "VARCHAR(2048)"]
+        [:status :tinyint]
+        [:failure "VARCHAR(2048)"]
+        [:heartbeat :int]
+        [:lock_version "INT NOT NULL DEFAULT '0'"]
+        [:created_at :datetime]
+        [:updated_at :datetime]]
+       (get default-table-opts adapter {}))
+     (j/create-table-ddl
+       :overseer_dependencies
+       [[:job_id "VARCHAR(64)"]
+        [:dep_id "VARCHAR(64)"]]
+       (get default-table-opts adapter {}))
+     "CREATE INDEX index_overseer_jobs_on_status ON overseer_jobs (status)"
+     "CREATE INDEX index_overseer_dependencies_on_job_id ON overseer_dependencies (job_id)"
+     "CREATE INDEX index_overseer_dependencies_on_dep_id ON overseer_dependencies (dep_id)"])
+  :ok)
+
+(defrecord JdbcStore [adapter db-spec]
+  core/Store
+  (install [this]
+    (install' adapter db-spec))
+
+  (transact-graph [this graph]
+    (assert (core/valid-graph? graph))
+    (let [now (clj-time/now)
+          job-rows (->> graph
+                        loom.graph/nodes
+                        (map job->jdbc-map)
+                        (map #(assoc % :created_at now :updated_at now)))
+          dep-rows (job-dep-jdbc-maps graph)]
+      (j/with-db-transaction [t-con db-spec]
+        (j/insert-multi! t-con :overseer_jobs job-rows)
+        (j/insert-multi! t-con :overseer_dependencies dep-rows))))
+
+  (job-info [this job-id]
+    (query-job db-spec job-id))
+
+  (reserve-job [this job-id]
+    (let [where-map {:status (:unstarted status-code)}
+          set-map {:status (:started status-code)
+                   :heartbeat (core/heartbeat)}]
+      (when (update-job db-spec job-id where-map set-map)
+        (query-job db-spec job-id))))
+
+  (finish-job [this job-id]
+    (let [where-map {:status (:started status-code)}
+          set-map {:status (:finished status-code)}]
+      (-> (update-job db-spec job-id where-map set-map)
+          (assert (str "Update failed for job: " job-id)))))
+
+  (fail-job [this job-id failure]
+    (let [where-map {:status (:started status-code)}
+          set-map {:status (:failed status-code)
+                   :failure (pr-str failure)}]
+      (-> (update-job db-spec job-id where-map set-map)
+          (assert (str "Update failed for job: " job-id)))))
+
+  (heartbeat-job [this job-id]
+    (-> (update-job db-spec job-id {} {:heartbeat (core/heartbeat)})
+        (assert (str "Update failed for job: " job-id))))
+
+  (abort-job [this job-id]
+    (let [job-ids (cons job-id (dependents db-spec job-id))]
+      (->> {:update :overseer_jobs
+            :set {:status (:aborted status-code)
+                  :updated_at (clj-time/now)}
+            :where [:in :id job-ids]}
+           sql/format
+           (j/db-do-prepared db-spec))))
+
+  (reset-job [this job-id]
+    (let [where-map {:status (:started status-code)}
+          set-map {:status (:unstarted status-code)
+                   :heartbeat (core/heartbeat)}]
+      (update-job db-spec job-id where-map set-map)))
+
+  (jobs-ready [this]
+    (->> {:select [:id]
+          :from [:overseer_jobs]
+          :where
+          [:and
+           [:= :status (:unstarted status-code)]
+           [:not-in :id
+            {:select [:job_id] :from [:overseer_dependencies]
+             :join [:overseer_jobs [:= :overseer_jobs.id :overseer_dependencies.dep_id]]
+             :where [:not= :overseer_jobs.status (:finished status-code)]}]]}
+         sql/format
+         (j/query db-spec)
+         (map :id)))
+
+  (jobs-dead [this thresh]
+    (->> {:select [:id]
+          :from [:overseer_jobs]
+          :where [:and
+                  [:= :status (:started status-code)]
+                  [:< :heartbeat thresh]]}
+         sql/format
+         (j/query db-spec)
+         (map :id))))
+
+(defn store [{:keys [adapter db-spec] :as config}]
+  {:pre [adapter db-spec]}
+  (->JdbcStore adapter db-spec))

--- a/test/overseer/core_test.clj
+++ b/test/overseer/core_test.clj
@@ -57,6 +57,22 @@
           graph (loom.graph/digraph {j0 []})]
       (is (not (core/valid-graph? graph))))))
 
+(defn uuid [s]
+  (try (java.util.UUID/fromString s)
+       (catch IllegalArgumentException ex nil)))
+
+(deftest test-job-graph
+  (let [job-type-graph
+        {:start []
+         :process [:start]
+         :finish [:process]}
+        tx {:org/id 123}
+        graph (core/job-graph job-type-graph tx)
+        jobs (loom.graph/nodes graph)]
+    (is (every? uuid (map :job/id jobs)))
+    (is (every? (partial = :unstarted) (map :job/status jobs)))
+    (is (every? (partial = 123) (map #(get-in % [:job/args :org/id]) jobs)))))
+
 (deftest test-missing-handlers
   (let [handlers {:foo (fn [_] nil)
                   :bar (fn [_] nil)}

--- a/test/overseer/store/jdbc_test.clj
+++ b/test/overseer/store/jdbc_test.clj
@@ -1,0 +1,178 @@
+(ns overseer.store.jdbc-test
+ (:require [clojure.test :refer :all]
+           [clojure.java.jdbc :as j]
+           [clojure.string :as string]
+           [framed.std.core :as std]
+           [honeysql.core :as sql]
+           loom.graph
+           (overseer
+             [api :as api]
+             [core :as core]
+             [test-utils :as test-utils])
+           [overseer.store.jdbc :as store]
+           [overseer.store-test :as store-test]))
+
+(defn- test-store
+  "Generate a fresh/configured store against a new in-memory H2 DB"
+  []
+  (let [store
+        (store/store
+          {:adapter :h2
+           :db-spec
+           {:classname "org.h2.Driver"
+            :subprotocol "h2:mem://"
+            :subname (str (std/rand-alphanumeric 12) ";DB_CLOSE_DELAY=-1")
+            :user "sa" ; System Administrator username
+            :password ""}})]
+    (core/install store)
+    store))
+
+(deftest test-job->jdbc-map
+  (let [job {:job/id "foo-id"
+             :job/type "process"
+             :job/status :unstarted
+             :job/args {:customer_id 1}}]
+    (is (= {:id "foo-id"
+            :type "process"
+            :status (:unstarted store/status-code)
+            :args (pr-str {:customer_id 1})}
+           (store/job->jdbc-map job)))))
+
+(deftest test-jdbc-map->job
+  (let [jdbc-map {:id "foo-id"
+                  :type "process"
+                  :status (:unstarted store/status-code)
+                  :args (pr-str {:customer_id 1})}]
+    (is (= {:job/id "foo-id"
+            :job/type :process
+            :job/status :unstarted
+            :job/args {:customer_id 1}}
+           (store/jdbc-map->job jdbc-map)))))
+
+(deftest test-job-jdbc-map-roundtrip
+  (let [job (test-utils/job)]
+    (is (= job (store/jdbc-map->job (store/job->jdbc-map job))))))
+
+(deftest test-update-job
+  ; Test that optimistic concurrency is implemented correctly (via lock_version)
+  ; Start two concurrent update attempts on the same row; expect only 1 to win
+  ; and subsequently update the row / increment the lock
+  (let [{:keys [db-spec] :as store} (test-store)
+        {job-id :job/id :as job} (test-utils/job)
+
+        conflicts (atom 0)
+
+        attempt-update
+        (fn []
+          (when-not (store/update-job db-spec job-id {} {:status (:started store/status-code)})
+            (swap! conflicts inc)))]
+    (core/transact-graph store (api/simple-graph job))
+    (run! deref [(future (attempt-update))
+                 (future (attempt-update))])
+    (is (= 1 @conflicts))
+    (is (= 1 (store/query-lock-version db-spec job-id)))
+    (is (= :started (:job/status (store/query-job db-spec job-id))))))
+
+(deftest test-dependents
+  (let [{:keys [db-spec] :as store} (test-store)
+
+        j0 (test-utils/job {:job/id "j0"})
+        j1 (test-utils/job {:job/id "j1"})
+        j2 (test-utils/job {:job/id "j2"})
+
+        graph
+        (loom.graph/digraph
+          {j0 []
+           j1 [j0]
+           j2 [j1]})]
+    (core/transact-graph store graph)
+    (is (= #{"j1" "j2"} (store/dependents db-spec "j0")))))
+
+(deftest test-job-dep-jdbc-maps
+  (let [j0 (test-utils/job {:job/id "j0"})
+        j1 (test-utils/job {:job/id "j1"})
+        j2 (test-utils/job {:job/id "j2"})
+        j3 (test-utils/job {:job/id "j3"})
+
+        graph
+        (loom.graph/digraph
+          {j0 []
+           j1 [j0]
+           j2 []
+           j3 [j1 j2]})]
+    (is (= #{{:job_id "j1" :dep_id "j0"}
+             {:job_id "j3" :dep_id "j1"}
+             {:job_id "j3" :dep_id "j2"}}
+           (set (store/job-dep-jdbc-maps graph))))))
+
+(deftest test-transact-graph
+  (let [{:keys [db-spec] :as store} (test-store)
+        args {:org/id 123}
+        graph (core/job-graph
+                {:start []
+                 :process [:start]}
+                args)
+
+        jobs-by-type
+        (->> graph
+             loom.graph/nodes
+             (group-by :job/type)
+             (std/map-kv first))
+
+        _ (core/transact-graph store graph)]
+    (testing "job rows"
+      (let [jobs (j/query db-spec (sql/format {:select [:*] :from [:overseer_jobs]}))]
+        (is (= 2 (count jobs)))
+        (is (every? (partial = (:unstarted store/status-code)) (map :status jobs)))
+        (is (every? (partial = (pr-str args)) (map :args jobs)))
+        (is (every? (partial = 0) (map :lock_version jobs)))
+        (is (every? identity (map :created_at jobs)))
+        (is (every? identity (map :updated_at jobs)))))
+    (testing "dependency rows"
+      (let [deps (j/query db-spec (sql/format {:select [:*] :from [:overseer_dependencies]}))
+            start-id (:job/id (:start jobs-by-type))
+            process-id (:job/id (:process jobs-by-type))]
+        (is (= 1 (count deps)))
+        (is (= process-id (:job_id (first deps))))
+        (is (= start-id (:dep_id (first deps))))))))
+
+(def ^:private sql-type-timestamp 93) ; From sql.h; corresponds to datetime
+
+(deftest test-install
+  (let [{:keys [db-spec] :as store} (test-store)]
+    (testing "tables"
+      (let [tables-by-name
+            (->> {:select [:*] :from [:information_schema.tables]}
+                 sql/format
+                 (j/query db-spec)
+                 (group-by (comp string/lower-case :table_name))
+                 (std/map-kv first))]
+        (is (contains? tables-by-name "overseer_jobs"))
+        (is (contains? tables-by-name "overseer_dependencies"))) )
+    (testing "columns"
+      (let [cols-by-name
+            (fn [table-name]
+              (->> {:select [:*] :from [:information_schema.columns] :where [:= :table_name table-name]}
+                   sql/format
+                   (j/query db-spec)
+                   (group-by (comp string/lower-case :column_name))
+                   (std/map-kv first)))
+
+            job-cols-by-name (cols-by-name "OVERSEER_JOBS")
+            dep-cols-by-name (cols-by-name "OVERSEER_DEPENDENCIES")]
+        (are [ty col] (= ty (get-in job-cols-by-name [col :type_name]))
+          "VARCHAR" "id"
+          "VARCHAR" "type"
+          "VARCHAR" "args"
+          "TINYINT" "status"
+          "VARCHAR" "failure"
+          "INTEGER" "heartbeat"
+          "INTEGER" "lock_version")
+        (is (= sql-type-timestamp (get-in job-cols-by-name ["created_at" :data_type])))
+        (is (= sql-type-timestamp (get-in job-cols-by-name ["updated_at" :data_type])))
+        (are [ty col] (= ty (get-in dep-cols-by-name [col :type_name]))
+          "VARCHAR" "job_id"
+          "VARCHAR" "dep_id")))))
+
+(deftest test-protocol
+  (store-test/test-protocol test-store))

--- a/test/overseer/store_test.clj
+++ b/test/overseer/store_test.clj
@@ -122,16 +122,17 @@
           (core/reserve-job store job-id)
           (core/finish-job store job-id))
 
-        _ (core/transact-graph store graph)
-        jobs-ready (core/jobs-ready store)]
-    (is (contains? jobs-ready "j0-id"))
-    (is (not (contains? jobs-ready "j1-id")))
-    (is (not (contains? jobs-ready "j2-id")))
+        _ (core/transact-graph store graph)]
+    (let [jobs-ready (set (core/jobs-ready store))]
+      (is (contains? jobs-ready "j0-id"))
+      (is (not (contains? jobs-ready "j1-id")))
+      (is (not (contains? jobs-ready "j2-id"))))
     (start-and-finish "j0-id")
-    (is (contains? (core/jobs-ready store) "j1-id"))
-    (is (not (contains? jobs-ready "j2-id")))
+    (let [jobs-ready (set (core/jobs-ready store))]
+      (is (contains? jobs-ready "j1-id"))
+      (is (not (contains? jobs-ready "j2-id"))))
     (start-and-finish "j1-id")
-    (is (contains? (core/jobs-ready store) "j2-id"))))
+    (is (contains? (set (core/jobs-ready store) )"j2-id"))))
 
 (defn test-jobs-dead [store]
   (timbre/with-log-level :report


### PR DESCRIPTION
This adds an implementation of overseer.core/Store for JDBC-capable
backends such as MySQL. Two system tables are used - `overseer_jobs` for
tracking job id/type/status, and `overseer_dependencies` for linking
job_id/dep_id graph edges. Internally, HoneySQL [0] is used in
conjunction with `clojure.java.jdbc` for DB interactions.

A key aspect of the implementation is the optimistic concurrency control
[1] implemented via a `lock_version` column, much like Rails [2]. This
results in a read-then-update pattern when state-transitioning jobs,
where we expect no conflict in most cases (with the exception of job
reservation) and abort the transaction if the row has since changed.
There is a single bespoke integration test for the concurrent update
case, and it will be interesting to think about generalized model
checking in the future.

The JDBC `dependents` function is a slight modification of the
old `transitive-dependents` function, but now traverses the graph one
level at a time, rather than individually querying for each job.

While all store protocol tests pass on the new implementation, it will
be useful to do thorough workload testing before marking this
implementation as production-ready.

0: https://github.com/jkk/honeysql
1: https://en.wikipedia.org/wiki/Optimistic_concurrency_control
2:
http://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html
