### PR TITLE
Remove option to disable worker heartbeats

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -15,17 +15,15 @@ detector-sleep-time: 2000
 # Default: 10000
 sleep-time: 10000
 
-# Optional: Enable job heartbeats, whereby each node will periodically
-# persist a timestamp via the DB and also act as a monitor that resets
+# Optional: Configure job heartbeats, in which each node periodically
+# persists a timestamp via the DB and also act as a monitor that resets
 # other jobs detected to be failing heartbeat checks
 #
-#   enabled - Default: true
 #   sleep-time: How long to sleep between persisting heartbeats (per-worker)
 #               Default: 60000
 #   tolerance: How many heartbeats can fail before job is considered dead
 #              to be reset by a monitor (Default: 5)
 heartbeat:
-  enabled: true
   sleep-time: 60000
   tolerance: 5
 

--- a/src/overseer/config.clj
+++ b/src/overseer/config.clj
@@ -26,10 +26,6 @@
     :sleep-time - Optional; How long to sleep in ms if the job queue is empty (default: 10000)
 
     :heartbeat - map of optional attributes to configure worker heartbeating
-      :enabled - When enabled, each node will periodically persist a timestamp
-                 'heartbeat' via the DB and also act as a monitor resetting jobs
-                 detected to be failing heartbeat checks
-                 (default: true)
       :sleep-time - How long to sleep in ms before persisting heartbeat (per-worker)
                     (default: 60000)
       :tolerance - How many heartbeats can fail before job is considered dead
@@ -60,9 +56,6 @@
 
 (defn sleep-time [config]
   (get config :sleep-time 10000))
-
-(defn heartbeat?  [config]
-  (get-in config [:heartbeat :enabled] true))
 
 (defn heartbeat-sleep-time [config]
   (get-in config [:heartbeat :sleep-time] 60000))

--- a/src/overseer/worker.clj
+++ b/src/overseer/worker.clj
@@ -34,12 +34,10 @@
         (exc/start-executor config store job-handlers ready-jobs current-job)
 
         heartbeat-fut
-        (when (config/heartbeat? config)
-          (heartbeat/start-heartbeat config store current-job))
+        (heartbeat/start-heartbeat config store current-job)
 
         heartbeat-monitor-fut
-        (when (config/heartbeat? config)
-          (heartbeat/start-monitor config store))]
+        (heartbeat/start-monitor config store)]
     (std/map-from-keys
       detector-fut
       executor-fut


### PR DESCRIPTION
Worker heartbeats used to be optional via the `:heartbeat :enabled`
config option; however the system was never really set up with an
appropriate alternative execution strategy if disabled. In theory we
could re-institute the old behavior of considering started jobs eligible
if heartbeating is disabled, but there is not a tremendous amount of
value in supporting this.