### PR TITLE
Make overseer.core/transact-graph idempotent on job-ids

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
                  [honeysql "0.8.2"]
                  [com.h2database/h2 "1.4.195"]
                  [com.velisco/herbert "0.7.0"]
-                 [clj-time "0.12.2"]]
+                 [clj-time "0.12.2"]
+                 [mysql/mysql-connector-java "5.1.41"]]
   :plugins [[codox "0.8.13"]]
   :codox {:output-dir "doc/api"})

--- a/src/overseer/core.clj
+++ b/src/overseer/core.clj
@@ -111,8 +111,9 @@
     to be idempotent. Returns :ok on success")
 
   (transact-graph [this graph]
-    "Given a Graph, atomically transact all of its jobs/dependencies into the store.
-    Side-effecting only; return value is undefined (raises if transaction fails)")
+    "Given a Graph, atomically transact all of its jobs/dependencies into the store and
+    return it. Idempotent on job-ids in graph: if any job-ids already exist in store, will not
+    double insert *or* update (if different args supplied, for example)")
 
   (job-info [this job-id]
     "Given a job-id, return a Job")


### PR DESCRIPTION
In a distributed execution context it can be useful to use job-ids as
idempotence keys of sorts, and allow multiple graph transaction attempts
with only one succeeding. This makes store inserts idempontent on
job-ids; if multiple inserts with the same job-ids are attempted the
system will no-op and return the original graph without raising an
exception.