### PR TITLE
Fix NPE in heartbeat monitors

### DIFF
--- a/src/overseer/config.clj
+++ b/src/overseer/config.clj
@@ -29,7 +29,11 @@
       :sleep-time - How long to sleep in ms before persisting heartbeat (per-worker)
                     (default: 60000)
       :tolerance - How many heartbeats can fail before job is considered dead
-                 to be reset by a monitor (default: 5)"
+                 to be reset by a monitor (default: 5)
+
+      :monitor-shutdown - Boolean, whether to shutdown the system when the heartbeat
+                          monitor encounters an error (avoids running in a degraded state)
+                          Default: true"
   (:require [framed.std.core :as std]))
 
 (defn store-type [config]
@@ -62,6 +66,9 @@
 
 (defn failed-heartbeat-tolerance [config]
   (get-in config [:heartbeat :tolerance] 5))
+
+(defn monitor-shutdown? [config]
+  (get-in config [:heartbeat :monitor-shutdown] true))
 
 (defn sentry-dsn [config]
   (get-in config [:sentry :dsn]))

--- a/test/overseer/api_test.clj
+++ b/test/overseer/api_test.clj
@@ -88,7 +88,7 @@
 (deftest test-fault
   (timbre/with-log-level :report
     (let [config {}
-          store (test-utils/store)
+          store (test-utils/datomic-store)
           job-ran? (atom false)
           job-handlers {:bar (fn [job]
                                (reset! job-ran? true)

--- a/test/overseer/heartbeat_test.clj
+++ b/test/overseer/heartbeat_test.clj
@@ -1,0 +1,57 @@
+(ns overseer.heartbeat-test
+  (:require [clojure.test :refer :all]
+            [clj-time.core :as clj-time]
+            [framed.std.time :as std.time]
+            [taoensso.timbre :as timbre]
+            [overseer.api :as api]
+            [overseer.core :as core]
+            [overseer.heartbeat :as heartbeat]
+            [overseer.test-utils :as test-utils]))
+
+(defn test-start-heartbeat [store]
+  (timbre/with-log-level :report
+    (let [config {:heartbeat {:monitor-shutdown false}}
+          old-heartbeat
+          (-> (clj-time/now)
+              (clj-time/minus (clj-time/days 30))
+              std.time/datetime->unix)
+          {job-id :job/id :as job} (test-utils/job {:job/heartbeat old-heartbeat})
+          _ (core/transact-graph store (api/simple-graph job))
+          current-job (atom (core/job-info store job-id))
+
+          heartbeat-fut (heartbeat/start-heartbeat config store current-job)]
+      (try
+        (Thread/sleep 500)
+        (is (> (:job/heartbeat (core/job-info store job-id))
+               old-heartbeat)
+            "It transacts heartbeats to the current job")
+        (finally
+          (test-utils/silent-cancel heartbeat-fut))))))
+
+(defn test-start-monitor [store]
+  (timbre/with-log-level :report
+    (let [config {:heartbeat {:monitor-shutdown false}}
+          job (test-utils/job
+                {:job/heartbeat
+                 (-> (clj-time/now)
+                     (clj-time/minus (clj-time/days 30))
+                     std.time/datetime->unix)})
+          _ (core/transact-graph store (api/simple-graph job))
+
+          monitor-fut (heartbeat/start-monitor config store)]
+      (try
+        (Thread/sleep 500)
+        (is (= :unstarted
+               (:job/status (core/job-info store (:job/id job))))
+            "It resets jobs that have failed heartbeats")
+        (finally
+          (test-utils/silent-cancel monitor-fut))))))
+
+;;
+
+(defn test-heartbeats
+  "Run a test suite exercises heartbeat functionality, given a nullary
+  function to produce fresh Store instances"
+  [store-factory]
+  (test-start-heartbeat (store-factory))
+  (test-start-monitor (store-factory)))

--- a/test/overseer/test_utils.clj
+++ b/test/overseer/test_utils.clj
@@ -3,18 +3,42 @@
             loom.graph
             [framed.std.core :as std]
             [overseer.core :as core]
-            [overseer.store.datomic :as store.datomic]))
+            [overseer.store.datomic :as store.datomic]
+            [overseer.store.jdbc :as store.jdbc]))
 
-(defn bootstrap-datomic-uri
+(defn silent-cancel
+  "Cancel future `fut`, suppressing any exceptions that occur as a result"
+  [fut]
+  (try (future-cancel fut) (catch Exception ex nil)))
+
+(defn- bootstrap-datomic-uri
   "Create/bootstrap a fresh memory DB and return its uri"
   []
   (let [uri (str "datomic:mem://" (std/rand-alphanumeric 32))]
     (d/create-database uri)
-    (store.datomic/install' (d/connect uri))
     uri))
 
-(defn store []
-  (store.datomic/store (bootstrap-datomic-uri)))
+(defn datomic-store
+  "Generate a fresh/configured Datomic-backed Store"
+  []
+  (let [store (store.datomic/store (bootstrap-datomic-uri))]
+    (core/install store)
+    store))
+
+(defn jdbc-store
+  "Generate a fresh/configured in-memory H2-backed Store"
+  []
+  (let [store
+        (store.jdbc/store
+          {:adapter :h2
+           :db-spec
+           {:classname "org.h2.Driver"
+            :subprotocol "h2:mem://"
+            :subname (str (std/rand-alphanumeric 12) ";DB_CLOSE_DELAY=-1")
+            :user "sa" ; System Administrator username
+            :password ""}})]
+    (core/install store)
+    store))
 
 (defn job
   ([]


### PR DESCRIPTION
Heartbeat monitors were incorrectly written expecting
`overseer.core/jobs-dead` return a seq of job maps, whereas it is
actually spec'd to return job IDs. This leads to NPEs from a bad
destructure and subsequent update attempt. This is easily fixed, and an
integration test for the monitor has been added, tested against both
store implementations. Along the way, test store construction has been
moved centrally to the `test-utils` namespace.

Note: The default system shutdown behavior of the heartbeat monitor is
now configurable by `:heartbeat :monitor-shutdown` (default: true), as
this would otherwise trigger when canceling the monitor future in tests.