### PR TITLE
Do not sign releases to Clojars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,4 +21,6 @@
                  [clj-time "0.12.2"]
                  [mysql/mysql-connector-java "5.1.41"]]
   :plugins [[codox "0.8.13"]]
-  :codox {:output-dir "doc/api"})
+  :codox {:output-dir "doc/api"}
+  :deploy-repositories [["releases"  {:sign-releases false :url "https://clojars.org/repo"}]
+                        ["snapshots" {:sign-releases false :url "https://clojars.org/repo"}]])


### PR DESCRIPTION
It appears that Clojars has (temporarily?) stopped verifying jar
signatures. The key administration screens have been removed from the
UI, and from [0]:

```
In the wiki documentation it now says, simply that it will check
“if any signature is uploaded, then every artifact has a signature”
but what that is NOT saying is “we confirm the signature belongs to
the clojars account that is attempting to do the publishing”
```

```
...there were minimal security benefits from signing the JARs, as people
didn’t have a web of trust to validate that the GPG signature actually
chained to people they trusted
```

It seems that jar verification v2 is in the discussion phase: [1][2]
In the meantime this disables release signing following example by
re-frame [3]

0: https://clojureverse.org/t/please-how-do-you-configure-gpg-and-clojars/606/2

1: https://github.com/clojars/clojars-web/issues/562

2: https://github.com/clojars/clojars-web/issues/560

3: https://github.com/Day8/re-frame/blob/master/project.clj#L31