### PR TITLE
Rename Clojars deploy-repository

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,5 +22,4 @@
                  [mysql/mysql-connector-java "5.1.41"]]
   :plugins [[codox "0.8.13"]]
   :codox {:output-dir "doc/api"}
-  :deploy-repositories [["releases"  {:sign-releases false :url "https://clojars.org/repo"}]
-                        ["snapshots" {:sign-releases false :url "https://clojars.org/repo"}]])
+  :deploy-repositories [["clojars" {:sign-releases false :url "https://clojars.org/repo"}]])


### PR DESCRIPTION
Naming the deploy repository "clojars" preserves the common `lein deploy
clojars` workflow (instead of `lein deploy releases`, for example)