### PR TITLE
Add separable store backends, support SQLite

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,8 @@
                  [com.h2database/h2 "1.4.195"]
                  [com.velisco/herbert "0.7.0"]
                  [clj-time "0.12.2"]
-                 [mysql/mysql-connector-java "5.1.41"]]
+                 [mysql/mysql-connector-java "5.1.41"]
+                 [org.xerial/sqlite-jdbc "3.41.2.1"]]
   :plugins [[codox "0.8.13"]]
   :codox {:output-dir "doc/api"}
   :deploy-repositories [["clojars" {:sign-releases false :url "https://clojars.org/repo"}]])

--- a/src/overseer/api.clj
+++ b/src/overseer/api.clj
@@ -31,7 +31,8 @@
   (case (config/store-type config)
     :datomic (store.datomic/store (:uri (config/datomic-config config)))
     :mysql (store.jdbc/store (config/jdbc-config config))
-    :h2 (store.jdbc/store (config/jdbc-config config))))
+    :h2 (store.jdbc/store (config/jdbc-config config))
+    :sqlite (store.jdbc/store (config/jdbc-config config))))
 
 (defn start
   "Start the system inline given a config map, a Store implementation (see `store`)

--- a/src/overseer/config.clj
+++ b/src/overseer/config.clj
@@ -4,7 +4,7 @@
   of configuration options are:
 
     :store
-      :adapter - Required String backend store type to connect to. One of datomic, mysql, h2
+      :adapter - Required String backend store type to connect to. One of datomic, mysql, h2, sqlite
       :config - options to configure the selected adapter
         If Datomic:
           - map of :uri, required connection String, ex: \"datomic:free://localhost:4334/overseer\"
@@ -46,7 +46,7 @@
     (assert (:uri cfg) ":uri is required when using Datomic")
     cfg))
 
-(def jdbc-adapters #{:mysql :h2})
+(def jdbc-adapters #{:mysql :h2 :sqlite})
 
 (defn jdbc-config [config]
   (let [db-spec (get-in config [:store :config])

--- a/src/overseer/core.clj
+++ b/src/overseer/core.clj
@@ -1,7 +1,6 @@
 (ns ^:no-doc overseer.core
   "Internal core functions"
   (:require [clojure.set :as set]
-            [datomic.api :as d]
             [framed.std.core :as std]
             [miner.herbert :as h]
             (loom derived graph)))

--- a/src/overseer/store/jdbc.clj
+++ b/src/overseer/store/jdbc.clj
@@ -158,7 +158,8 @@
   (let [msg (.getMessage ex)]
     (case adapter
       :mysql (instance? MySQLIntegrityConstraintViolationException ex)
-      :h2 (re-find #"^Unique index or primary key violation" msg))))
+      :h2 (string/starts-with? msg "Unique index or primary key violation")
+      :sqlite (string/starts-with? msg "[SQLITE_CONSTRAINT_PRIMARYKEY]"))))
 
 (defrecord JdbcStore [adapter db-spec]
   core/Store

--- a/src/overseer/store/jdbc.clj
+++ b/src/overseer/store/jdbc.clj
@@ -11,8 +11,7 @@
             (loom graph)
             (overseer
               [core :as core]
-              [util :as util]))
-  (:import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException))
+              [util :as util])))
 
 (def status-code
   {:unstarted 0
@@ -157,7 +156,8 @@
 (defn dup-primary-key-ex? [adapter ex]
   (let [msg (.getMessage ex)]
     (case adapter
-      :mysql (instance? MySQLIntegrityConstraintViolationException ex)
+      :mysql (let [ex-class (Class/forName "com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException")]
+               (instance? ex-class ex))
       :h2 (string/starts-with? msg "Unique index or primary key violation")
       :sqlite (string/starts-with? msg "[SQLITE_CONSTRAINT_PRIMARYKEY]"))))
 


### PR DESCRIPTION
# Rationale

I want to use Overseer in a project that already heavily uses SQLite, so I thought I’d use the JDBC store, pointing it to a SQLite table. Also, because I won’t be using Datomic, MySQL, or H2, I wanted to exclude the unused libraries, specifying my Overseer dependency as:

```clojure
io.framed/overseer {:mvn/version "0.8.9"
                    :exclusions  [com.datomic/datomic-free
                                  com.h2database/h2
                                  mysql/mysql-connector-java]}
```

However, I ran into two problems:

- SQLite isn’t supported (only MySQL or H2).
- Excluding doesn’t work, as Overseer unconditionally loads the dependencies.

This PR rectifies both issues. Read individual commit descriptions to see how.

# How I checked it

- Made sure tests still pass
- Created a `deps.edn` that contains all deps from `project.clj`, except for the backend-specific ones other than sqlite, and launched a REPL with that
- Followed the quickstart and evaluated:

```clojure
(ns myapp.core
  (:require [overseer.api :as overseer]))

(def job-graph
  {:start []
   :result1 [:start]
   :result2 [:start]
   :finish [:result1 :result2]})

(def job-handlers
  {:start (fn [job] (println "start"))
   :result1 (fn [job] (println "result1"))
   :result2 (fn [job] (println "result2"))
   :finish (fn [job] (println "finish"))})

(def config {:store {:adapter "sqlite",
                     :config "jdbc:sqlite:/tmp/store.sqlite"}})

(def store (overseer/store config))

(overseer/start config store job-handlers) ; run the worker
(overseer/install store) ; set up store
(overseer/transact-graph store (overseer/job-graph job-graph)) ; fire up the job graph
```

Overseer successfully set up the SQLite store, created the jobs, and ran them to completion.

# What this PR doesn’t do

Now that Overseer is able to work with the chosen storage backend’s dependency only, I believe it makes sense to ask users to explicitly depend on that, rather than specify exclusions (it’s easier to add one dependency than to exclude three). In fact, the quickstart already makes such an ask.

However, I’m still not 100% convinced, and so this PR keeps the approach of including all deps. 